### PR TITLE
Use priority_weight instead of number of task by worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ opv2 ansible_host=192.168.1.3
 opv3 ansible_host=192.168.1.4
 ```
 
+For an example, you can look at the hosts_example file.
 
 ## The group_vars/all file
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -2,3 +2,4 @@ postgresPasswdAirflow: Testairflow42
 postgresPasswdOPV: Testopv42
 idMallette: POC
 OPVMaster: OPV_Master
+taskPerWorker: 4

--- a/hosts
+++ b/hosts
@@ -1,5 +1,0 @@
-[Master]
-master ansible_host=10.204.125.237
-
-[Worker]
-slave ansible_host=10.204.125.249

--- a/hosts
+++ b/hosts
@@ -1,5 +1,6 @@
 [Master]
-master ansible_host=192.168.5.16
+poil2 ansible_host=192.168.1.102
 
 [Worker]
-worker0 ansible_host=192.168.5.50
+poil1 ansible_host=192.168.1.101
+poil3 ansible_host=192.168.1.103

--- a/hosts_example
+++ b/hosts_example
@@ -1,0 +1,5 @@
+[Master]
+master ansible_host=10.229.187.21
+
+[Worker]
+slave ansible_host=10.229.187.33

--- a/roles/base/tasks/airflow.yml
+++ b/roles/base/tasks/airflow.yml
@@ -7,6 +7,7 @@
     name: "{{ item }}"
     virtualenv: /home/opv/venvs/opv
     virtualenv_command: pyvenv
+    state: latest
   with_items:
     - airflow
     - postgres
@@ -27,10 +28,11 @@
 
 - name: Create airflow directory
   file:
-    path: "/home/opv/airflow"
+    path: "/home/opv/airflow/dags"
     state: directory
     owner: opv
     group: opv
+    recurse: yes
     mode: 0755
 
 - name: Setup Airflow services

--- a/roles/base/tasks/opv.yml
+++ b/roles/base/tasks/opv.yml
@@ -46,11 +46,13 @@
     virtualenv_command: pyvenv
     editable: false
     extra_args: "--process-dependency-links"
+    state: latest
   with_items:
     - https://github.com/OpenPathView/DirectoryManager
     - https://github.com/OpenPathView/OPV_DBRest.git
     - https://github.com/OpenPathView/OPV_importData.git
     - https://github.com/OpenPathView/OPV_Tasks.git
+    - https://github.com/OpenPathView/OPV_Dags.git
   become: yes
   become_user: opv
 
@@ -69,7 +71,7 @@
   with_items:
     - api
     - dm
-    
+
 - name: Setup OPV service
   template:
     src: "{{ item }}-service.j2"

--- a/roles/base/templates/airflow.service.j2
+++ b/roles/base/templates/airflow.service.j2
@@ -8,7 +8,8 @@ Type=simple
 User=opv
 
 ExecStart=/home/opv/bin/launch_airflow_service.sh {{ item }}
-
+KillSignal=SIGKILL
+KillMode=mixed
 Restart=on-failure
 
 

--- a/roles/configuration/tasks/main.yml
+++ b/roles/configuration/tasks/main.yml
@@ -46,3 +46,11 @@
     owner: opv
     group: opv
     mode: 0744
+
+- name: Setup dag
+  template:
+    src: campaign.py
+    dest: /home/opv/airflow/dags/campaign.py
+    owner: opv
+    group: opv
+    mode: 0744

--- a/roles/configuration/templates/airflow.cfg
+++ b/roles/configuration/templates/airflow.cfg
@@ -71,7 +71,7 @@ fernet_key = cryptography_not_found_storing_passwords_in_plain_text
 donot_pickle = False
 
 # How long before timing out a python file import while filling the DagBag
-dagbag_import_timeout = 30
+dagbag_import_timeout = 600
 
 
 [operators]

--- a/roles/configuration/templates/airflow.cfg
+++ b/roles/configuration/templates/airflow.cfg
@@ -141,7 +141,7 @@ celery_app_name = airflow.executors.celery_executor
 # "airflow worker" command. This defines the number of task instances that
 # a worker will take, so size up your workers based on the resources on
 # your worker box and the nature of your tasks
-celeryd_concurrency = 1
+celeryd_concurrency = {{ taskPerWorker }}
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main

--- a/roles/configuration/templates/campaign.py
+++ b/roles/configuration/templates/campaign.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# email: nouchet.christophe@gmail.com
+# Desciption: This script will generate all the dags necessary to build a campaign
+
+import airflow
+
+from airflow import DAG
+from opv_dags import create_dag_make_compaign
+from  opv_api_client import RestClient, Filter
+from opv_api_client.ressources import Campaign
+
+args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'start_date': airflow.utils.dates.days_ago(2),
+    'retries': 0
+}
+
+NB_WORKER = {{ groups['Worker'] | length * taskPerWorker}}
+
+# Get all the campaigns
+db_client = RestClient("http://OPV_Master:5000")
+campaigns = db_client.make_all(Campaign)
+
+for campaign in campaigns:
+    print(
+        "Create dag for the campaign %s, id_malette=%s and id_campaign=%s" % (
+            campaign.name, campaign.id_malette, campaign.id_campaign
+        )
+    )
+
+    # Sub_dag version
+    # globals()[
+    #     "subdag_%s_%s_%s" % (campaign.name, campaign.id_malette, campaign.id_campaign)
+    # ] = create_dag_make_compaign(
+    #     campaign.name, campaign.id_malette, campaign.id_campaign, args, NB_WORKER, subdag=True
+    # )
+    globals()[
+        "%s_%s_%s" % (campaign.name, campaign.id_malette, campaign.id_campaign)
+        ] = create_dag_make_compaign(
+        campaign.name, campaign.id_malette, campaign.id_campaign, args, NB_WORKER
+    )

--- a/roles/configuration/templates/campaign.py
+++ b/roles/configuration/templates/campaign.py
@@ -17,8 +17,6 @@ args = {
     'retries': 0
 }
 
-NB_WORKER = {{ groups['Worker'] | length * taskPerWorker}}
-
 # Get all the campaigns
 db_client = RestClient("http://OPV_Master:5000")
 campaigns = db_client.make_all(Campaign)
@@ -30,14 +28,8 @@ for campaign in campaigns:
         )
     )
 
-    # Sub_dag version
-    # globals()[
-    #     "subdag_%s_%s_%s" % (campaign.name, campaign.id_malette, campaign.id_campaign)
-    # ] = create_dag_make_compaign(
-    #     campaign.name, campaign.id_malette, campaign.id_campaign, args, NB_WORKER, subdag=True
-    # )
     globals()[
         "%s_%s_%s" % (campaign.name, campaign.id_malette, campaign.id_campaign)
         ] = create_dag_make_compaign(
-        campaign.name, campaign.id_malette, campaign.id_campaign, args, NB_WORKER
+        campaign.name, campaign.id_malette, campaign.id_campaign, args
     )

--- a/roles/configuration/templates/campaign.py
+++ b/roles/configuration/templates/campaign.py
@@ -6,8 +6,8 @@
 import airflow
 
 from airflow import DAG
-from opv_dags import create_dag_make_compaign
-from  opv_api_client import RestClient, Filter
+from opv_dags import make_campaign
+from opv_api_client import RestClient, Filter
 from opv_api_client.ressources import Campaign
 
 args = {
@@ -30,6 +30,6 @@ for campaign in campaigns:
 
     globals()[
         "%s_%s_%s" % (campaign.name, campaign.id_malette, campaign.id_campaign)
-        ] = create_dag_make_compaign(
+    ] = make_campaign(
         campaign.name, campaign.id_malette, campaign.id_campaign, args
     )


### PR DESCRIPTION
For the "Les Vieilles Charrues 2017" we use the number of task by worker to create the dag. This is not optimal at all, so it's better to use the priority_weight. So, now the dag doesn't have to know the number worker.